### PR TITLE
Bugfix/pre api 18 crop fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.0.1'
+    classpath 'com.android.tools.build:gradle:1.3.0'
     classpath 'com.github.dcendents:android-maven-plugin:1.2'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
   }

--- a/cropimageview-samples/build.gradle
+++ b/cropimageview-samples/build.gradle
@@ -12,12 +12,12 @@ buildscript {
 }
 
 android {
-  compileSdkVersion 21
+  compileSdkVersion 23
   buildToolsVersion "21.1.2"
   defaultConfig {
     applicationId 'com.cesards.android.samples.cropimageview'
     minSdkVersion 14
-    targetSdkVersion 21
+    targetSdkVersion 23
     versionCode 1
     versionName "1.0.1"
   }
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-v4:22.2.0'
+  compile 'com.android.support:appcompat-v7:23.1.0'
   compile 'me.relex:circleindicator:1.1.1@aar'
   compile 'com.jakewharton:butterknife:6.1.0'
   compile 'com.cesards.android:foregroundviews:1.0.0'

--- a/cropimageview/build.gradle
+++ b/cropimageview/build.gradle
@@ -1,14 +1,13 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 android {
-  compileSdkVersion 21
+  compileSdkVersion 23
   buildToolsVersion "21.1.2"
 
   defaultConfig {
     minSdkVersion 14
-    targetSdkVersion 21
+    targetSdkVersion 23
     versionCode 2
     versionName "1.0.1"
   }
@@ -19,81 +18,18 @@ android {
   }
 }
 
-def siteUrl = 'https://github.com/cesards/CropImageView'          // Homepage URL of the library
-def gitUrl = 'https://github.com/cesards/CropImageView.git'       // Git repository URL
+dependencies {
+  compile 'com.android.support:support-annotations:23.1.0'
+}
+
+def siteUrl = 'https://github.com/cesards/CropImageView'
+// Homepage URL of the library
+def gitUrl = 'https://github.com/cesards/CropImageView.git'
+// Git repository URL
 // This is the library version used when deploying the artifact
 version = "1.0.1"
 group = "com.cesards.android"
 
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-
-bintray {
-  user = properties.getProperty("bintray.user")
-  key = properties.getProperty("bintray.apikey")
-
-  configurations = ['archives']
-  pkg {
-    repo = "maven"
-    name = "CropImageView"
-    websiteUrl = siteUrl
-    vcsUrl = gitUrl
-    licenses = ["Apache-2.0"]
-    publish = true
-  }
-}
-
-install {
-  repositories.mavenInstaller {
-    // This generates POM.xml with proper parameters
-    pom {
-      project {
-        packaging 'aar'
-
-        // Add your description here
-        name 'Crop ImageView'
-        url siteUrl
-
-        // Set your license
-        licenses {
-          license {
-            name 'The Apache Software License, Version 2.0'
-            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-          }
-        }
-        developers {
-          developer {
-            id 'cesards'
-            name 'César Díez'
-            email 'cesaryomismo@gmail.com'
-          }
-        }
-        scm {
-          connection gitUrl
-          developerConnection gitUrl
-          url siteUrl
-
-        }
-      }
-    }
-  }
-}
-
-task sourcesJar(type: Jar) {
-  from android.sourceSets.main.java.srcDirs
-  classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-  source = android.sourceSets.main.java.srcDirs
-  classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
-  from javadoc.destinationDir
-}
-artifacts {
-  archives javadocJar
-  archives sourcesJar
-}
+Properties properties = new Properties( )
+properties.load(project.rootProject.file('local.properties').
+    newDataInputStream( ))

--- a/cropimageview/src/main/java/com/cesards/cropimageview/API18Image.java
+++ b/cropimageview/src/main/java/com/cesards/cropimageview/API18Image.java
@@ -1,0 +1,16 @@
+package com.cesards.cropimageview;
+
+import android.graphics.Matrix;
+import android.widget.ImageView;
+
+public class API18Image extends CropImage implements ImageMaths {
+
+    public API18Image(CropImageView imageView) {
+        super(imageView);
+    }
+
+    @Override
+    public Matrix getMatrix() {
+        return imageView.getImageMatrix();
+    }
+}

--- a/cropimageview/src/main/java/com/cesards/cropimageview/CropImage.java
+++ b/cropimageview/src/main/java/com/cesards/cropimageview/CropImage.java
@@ -1,0 +1,13 @@
+package com.cesards.cropimageview;
+
+import android.support.annotation.NonNull;
+import android.widget.ImageView;
+
+public abstract class CropImage {
+
+    protected final @NonNull CropImageView imageView;
+
+    public CropImage(@NonNull CropImageView imageView) {
+        this.imageView = imageView;
+    }
+}

--- a/cropimageview/src/main/java/com/cesards/cropimageview/CropImageView.java
+++ b/cropimageview/src/main/java/com/cesards/cropimageview/CropImageView.java
@@ -28,26 +28,30 @@ import java.util.Map;
 
 public class CropImageView extends ImageView {
 
+  private ImageMaths imageMaths;
   private CropType cropType = CropType.NONE;
 
   public CropImageView(Context context) {
     super(context);
+
+    initImageView();
   }
 
   public CropImageView(Context context, AttributeSet attrs) {
-    super(context, attrs);
-    this.parseAttributes(attrs);
+    this(context, attrs, 0);
   }
 
   public CropImageView(Context context, AttributeSet attrs, int defStyle) {
-    super(context, attrs, defStyle);
-    this.parseAttributes(attrs);
+    this(context, attrs, defStyle, 0);
   }
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public CropImageView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
     super(context, attrs, defStyleAttr, defStyleRes);
-    this.parseAttributes(attrs);
+
+    parseAttributes(attrs);
+
+    initImageView();
   }
 
   /**
@@ -76,16 +80,20 @@ public class CropImageView extends ImageView {
    * @return a {@link CropType} in use by this ImageView
    */
   public CropType getCropType() {
-    return this.cropType;
+    return cropType;
+  }
+
+  private void initImageView() {
+    imageMaths = new ImageMathsFactory().getImageMaths(this);
   }
 
   private void parseAttributes(AttributeSet attrs) {
-    TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.CropImageView);
+    final TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.CropImageView);
 
     final int crop = a.getInt(R.styleable.CropImageView_crop, CropType.NONE.getCrop());
     if (crop >= 0) {
       setScaleType(ScaleType.MATRIX);
-      this.cropType = CropType.get(crop);
+      cropType = CropType.get(crop);
     }
     a.recycle();
   }
@@ -94,7 +102,7 @@ public class CropImageView extends ImageView {
   protected boolean setFrame(int l, int t, int r, int b) {
     final boolean changed = super.setFrame(l, t, r, b);
     if (!isInEditMode()) {
-      this.computeImageMatrix();
+      computeImageMatrix();
     }
     return changed;
   }
@@ -104,10 +112,10 @@ public class CropImageView extends ImageView {
     final int viewHeight = getHeight() - getPaddingTop() - getPaddingBottom();
 
     if (cropType != CropType.NONE && viewHeight > 0 && viewWidth > 0) {
-      final Matrix matrix = getImageMatrix();
+      final Matrix matrix = imageMaths.getMatrix();
 
-      int drawableWidth = getDrawable().getIntrinsicWidth();
-      int drawableHeight = getDrawable().getIntrinsicHeight();
+      final int drawableWidth = getDrawable().getIntrinsicWidth();
+      final int drawableHeight = getDrawable().getIntrinsicHeight();
 
       final float scaleY = (float) viewHeight / (float) drawableHeight;
       final float scaleX = (float) viewWidth / (float) drawableWidth;

--- a/cropimageview/src/main/java/com/cesards/cropimageview/ImageMaths.java
+++ b/cropimageview/src/main/java/com/cesards/cropimageview/ImageMaths.java
@@ -1,0 +1,7 @@
+package com.cesards.cropimageview;
+
+import android.graphics.Matrix;
+
+public interface ImageMaths {
+    Matrix getMatrix();
+}

--- a/cropimageview/src/main/java/com/cesards/cropimageview/ImageMathsFactory.java
+++ b/cropimageview/src/main/java/com/cesards/cropimageview/ImageMathsFactory.java
@@ -1,0 +1,12 @@
+package com.cesards.cropimageview;
+
+import android.os.Build;
+import android.support.annotation.NonNull;
+
+public class ImageMathsFactory {
+
+  public ImageMaths getImageMaths(@NonNull CropImageView imageView) {
+    final boolean preApi18 = Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2;
+    return preApi18 ? new PreApi18CropImage(imageView) : new API18Image(imageView);
+  }
+}

--- a/cropimageview/src/main/java/com/cesards/cropimageview/PreApi18CropImage.java
+++ b/cropimageview/src/main/java/com/cesards/cropimageview/PreApi18CropImage.java
@@ -1,0 +1,25 @@
+package com.cesards.cropimageview;
+
+import android.graphics.Matrix;
+
+public class PreApi18CropImage extends CropImage implements ImageMaths {
+
+  private Matrix matrix;
+
+  public PreApi18CropImage(CropImageView imageView) {
+    super(imageView);
+
+    init(imageView);
+  }
+
+  private void init(CropImageView imageView) {
+    if (imageView.getCropType() != CropImageView.CropType.NONE) {
+      matrix = new Matrix();
+    }
+  }
+
+  @Override
+  public Matrix getMatrix() {
+    return matrix == null ? imageView.getImageMatrix() : matrix;
+  }
+}


### PR DESCRIPTION
This closes #12 

I found a very good answer to the problem [__here__](http://stackoverflow.com/questions/20431374/bug-with-android-4-3-imageview-method-getimagematrix)
Before API 18, the `setImageMatrix(Matrix matrix)` is saving the matrix in a different field than `getImageMatrix()` is returning...

Android 4.4 ImageView
```java
public void setImageMatrix(Matrix matrix) {
    // collaps null and identity to just null
    if (matrix != null && matrix.isIdentity()) {
        matrix = null;
    }

    // don't invalidate unless we're actually changing our matrix
    if (matrix == null && !mMatrix.isIdentity() ||
            matrix != null && !mMatrix.equals(matrix)) {
        mMatrix.set(matrix);
        configureBounds();
        invalidate();
    }
}
```
Here the matrix is being stored in the field mMatrix
```java
public Matrix getImageMatrix() {
    if (mDrawMatrix == null) { //<-- should be mMatrix == null
        return new Matrix(Matrix.IDENTITY_MATRIX);
    }
    return mDrawMatrix; //<-- NOT THE RIGHT FIELD TO RETURN
}
```
While `getImageMatrix()` returns `mDrawMatrix`...

Android 4.1.2 ImageView
```java
public Matrix getImageMatrix() {
    return mMatrix;
}

public void setImageMatrix(Matrix matrix) {
    // collaps null and identity to just null
    if (matrix != null && matrix.isIdentity()) {
        matrix = null;
    }

    // don't invalidate unless we're actually changing our matrix
    if (matrix == null && !mMatrix.isIdentity() ||
            matrix != null && !mMatrix.equals(matrix)) {
        mMatrix.set(matrix);
        configureBounds();
        invalidate();
    }
}
```
both methods use the same field - `mMatrix`

__SOLUTION: preserve `Matrix` as field instead of retrieving it from `ImageView` in API < 18__

