### PR TITLE
Fix view path in the xml docu

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ dependencies {
 ### Step 2
 Define in xml:
 ```xml
-<com.codeforvictory.android.superimageview.SuperImageView
+<<com.cesards.cropimageview.CropImageView
    xmlns:custom="http://schemas.android.com/apk/res-auto"
    android:id="@+id/imageView1"
    android:src="@drawable/photo1"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ dependencies {
 ### Step 2
 Define in xml:
 ```xml
-<<com.cesards.cropimageview.CropImageView
+<com.cesards.cropimageview.CropImageView
    xmlns:custom="http://schemas.android.com/apk/res-auto"
    android:id="@+id/imageView1"
    android:src="@drawable/photo1"


### PR DESCRIPTION
The documentation states that you should use `com.codeforvictory.android.superimageview.SuperImageView` for your view in xml. This didn't work for me and had to adjust it to `com.cesards.cropimageview.CropImageView`. I thought the docu should represent this correctly.